### PR TITLE
Fix table score creation bug

### DIFF
--- a/firebase.js
+++ b/firebase.js
@@ -75,7 +75,11 @@ export async function updateScore(pseudo, mode, difficulty, increment = 1) {
           multiplications: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 },
           tables: 0,
         };
-        newData[mode][difficulty] = increment;
+        if (mode === "tables") {
+          newData[mode] = increment;
+        } else {
+          newData[mode][difficulty] = increment;
+        }
         await setDoc(userRef, newData);
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- correct score initialization in `updateScore` when creating new user

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861698813308328989a6294b338024d